### PR TITLE
Fix jump search

### DIFF
--- a/jump_search.js
+++ b/jump_search.js
@@ -5,15 +5,23 @@
 // linear search of each value between previous jumps step and current.
 
 // @return index of target element in array
-const jumpSearch = (array, target, start = 0, stop = array.length, jumpStep = Math.floor(Math.sqrt(array.length-1))) => {
-    for(let i = start; i <= stop; i +=jumpStep) {
+const jumpSearch = (array, target, start = 0, stop = array.length - 1, jumpStep = Math.floor(Math.sqrt(array.length))) => {
+    if (start > stop) {
+        return -1;
+    }
+
+    for (let i = start; i <= stop; i += jumpStep) {
         if (array[i] === target) {
             return i;
-        } else if (array[i] > target) {
-            let previouseI = i-jumpStep;
-            return jumpSearch(array, target, previouseI, i+1, 1);
+        }
+
+        if (array[i] > target) {
+            const previous = i - jumpStep;
+            return jumpSearch(array, target, previous, i - 1, 1);
         }
     }
+
+    return -1;
 }
 
 let numbers = [0,1,22,33,44,55,66,77,88,99];


### PR DESCRIPTION
## Summary
- fix recursion stopping condition for jump search
- return `-1` for unfound values

## Testing
- `node arrayClass.js`
- `node binary_search.js`
- `node buble_sort.js`
- `node insertion_sort.js`
- `node jump_search.js`
- `node - <<'NODE'
const fs=require('fs');
let src=fs.readFileSync('jump_search.js','utf8');
let func=new Function(src+"; return jumpSearch([1,2,3,5,6], 4);");
console.log(func());
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6849545a4dac8324b50a49dac35c83b3